### PR TITLE
added Term::ReadLine::EditLine support

### DIFF
--- a/lib/Term/ReadLine.pm
+++ b/lib/Term/ReadLine.pm
@@ -344,7 +344,7 @@ if ($which) {
 } elsif (defined $which and $which ne '') {	# Defined but false
   # Do nothing fancy
 } else {
-  eval "use Term::ReadLine::Gnu; 1" or eval "use Term::ReadLine::Perl; 1";
+  eval "use Term::ReadLine::Gnu; 1" or eval "use Term::ReadLine::EditLine; 1" or eval "use Term::ReadLine::Perl; 1";
 }
 
 #require FileHandle;
@@ -354,6 +354,8 @@ if ($which) {
 our @ISA;
 if (defined &Term::ReadLine::Gnu::readline) {
   @ISA = qw(Term::ReadLine::Gnu Term::ReadLine::Stub);
+} elsif (defined &Term::ReadLine::EditLine::readline) {
+  @ISA = qw(Term::ReadLine::EditLine Term::ReadLine::Stub);
 } elsif (defined &Term::ReadLine::Perl::readline) {
   @ISA = qw(Term::ReadLine::Perl Term::ReadLine::Stub);
 } elsif (defined $which && defined &{"Term::ReadLine::$which\::readline"}) {


### PR DESCRIPTION
I released Term::ReadLine::EditLine to support libedit with Term::ReadLine interface.
I think Term;:ReadLine::Gnu to install mac osx is too hard for newbies, but Term::ReadLine::EditLine is easy to install for osx.

If Term::ReadLine fallback to Term::ReadLine::EditLine, OSX users will be happy.
