### PR TITLE
Add Term::ReadLine::Perl5 support

### DIFF
--- a/lib/Term/ReadLine.pm
+++ b/lib/Term/ReadLine.pm
@@ -181,7 +181,7 @@ None
 The environment variable C<PERL_RL> governs which ReadLine clone is
 loaded. If the value is false, a dummy interface is used. If the value
 is true, it should be tail of the name of the package to use, such as
-C<Perl> or C<Gnu>.
+C<Perl>, C<Perl5>, C<Gnu>, C<Stub>, C<TermCap>, or C<Tk>.
 
 As a special case, if the value of this variable is space-separated,
 the tail might be used to disable the ornaments by setting the tail to

--- a/t/Perl5.t
+++ b/t/Perl5.t
@@ -1,0 +1,16 @@
+#!perl
+
+use Test::More;
+eval "use Term::ReadLine::Perl5; 1" or
+    plan skip_all => "Term::ReadLine::Perl5 not installed.";
+
+$ENV{PERL_RL} = 'Perl5';
+
+use File::Basename;
+use File::Spec;
+$term_readline=File::Spec->catfile(dirname(__FILE__), '..', 'lib', 'Term', 'ReadLine.pm');
+require $term_readline;
+$term = Term::ReadLine->new('T:R:P5');
+ok($term, "Created term object");
+is($term->ReadLine, 'Term::ReadLine::Perl5', 'Correct type');
+done_testing();


### PR DESCRIPTION
The $isa_done stuff might be a little hoaky. Would like to not interfere with the Term::ReadLine::EditLine request but the two things do about the same thing and I don't see a way to avoid patches to not conflict.
